### PR TITLE
Update metadata.json for Gnome 43

### DIFF
--- a/volume_scroller@trflynn89.pm.me/metadata.json
+++ b/volume_scroller@trflynn89.pm.me/metadata.json
@@ -7,7 +7,8 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/trflynn89/gnome-shell-volume-scroller",
   "uuid": "volume_scroller@trflynn89.pm.me",


### PR DESCRIPTION
Upon updating to ubuntu 22.10 I lost the volume scroller and after 24 hours couldn't stand it any longer. Turns out the fix is super easy.

Tested and worksforme (TM)!